### PR TITLE
Typo in documentation of register_sum callback

### DIFF
--- a/src/hyper_register.erl
+++ b/src/hyper_register.erl
@@ -37,7 +37,7 @@
                     hyper:registers()) ->
     hyper:registers().
 
-%% @doc: Sum of 2^R where R is the value in each register.
+%% @doc: Sum of 2^-R where R is the value in each register.
 -callback register_sum(hyper:registers()) ->
     float().
 


### PR DESCRIPTION
@knutin, correct me if I'm wrong, but judging from your reference implementations it seems that register_sum is supposed to sum over `2^-R` instead of `2^R`, yes?
