### PR TITLE
Release resource created for merge result

### DIFF
--- a/c_src/hyper_carray.c
+++ b/c_src/hyper_carray.c
@@ -186,7 +186,9 @@ static ERL_NIF_TERM max_merge(ErlNifEnv * env, int argc,
 		return enif_make_badarg(env);
 	}
 
-	return enif_make_resource(env, acc);
+	ERL_NIF_TERM erl_res = enif_make_resource(env, acc);
+	enif_release_resource(acc);
+	return erl_res;
 }
 
 /*

--- a/c_src/hyper_carray.c
+++ b/c_src/hyper_carray.c
@@ -128,7 +128,7 @@ static ERL_NIF_TERM set(ErlNifEnv * env, int argc,
 
 	carray_merge_item(arr, index, new_value);
 
-	return enif_make_resource(env, arr);
+	return argv[2];
 }
 
 void dtor(ErlNifEnv * env, void *obj);


### PR DESCRIPTION
This fixes a binary reference leak on the carray merge function. The new created resource was not released and therefore the gc was not able to de-allocate. The problem is illustrated in these snippets:

https://gist.github.com/elverkilde/c088e99c69c965a73056 (before)

https://gist.github.com/elverkilde/5b1ff1b9e69d26bc951c (after)

I am not sure if the set function suffers from the same problem, but I assume not.