### PR TITLE
Module random is deprecated since Erlang R18

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ for lower cardinalities.
 
 The errors introduced by estimations can be seen in this example:
 ```erlang
-3> random:seed(1,2,3).
-undefined
-4> Run = fun (P, Card) -> hyper:card(lists:foldl(fun (_, H) -> Int = random:uniform(10000000000000), hyper:insert(<<Int:64/integer>>, H) end, hyper:new(P), lists:seq(1, Card))) end.
+3> rand:seed(exs1024, {1, 2, 3}).
+ ...
+4> Run = fun (P, Card) -> hyper:card(lists:foldl(fun (_, H) -> Int = rand:uniform(10000000000000), hyper:insert(<<Int:64/integer>>, H) end, hyper:new(P), lists:seq(1, Card))) end.
 #Fun<erl_eval.12.80484245>
 5> Run(12, 10000).
 9992.846462080579

--- a/src/hyper.erl
+++ b/src/hyper.erl
@@ -242,7 +242,7 @@ random_bytes(N) ->
 
 random_bytes(Acc, 0) -> Acc;
 random_bytes(Acc, N) ->
-    Int = random:uniform(100000000000000),
+    Int = rand:uniform(100000000000000),
     random_bytes([<<Int:64/integer>> | Acc], N-1).
 
 
@@ -285,9 +285,9 @@ run_report(P, Card, Repetitions) ->
                           fun (I) ->
                                   io:format("~p values with p=~p, rep ~p~n",
                                             [Card, P, I]),
-                                  random:seed(erlang:phash2([node()]),
+                                  rand:seed(exs1024, {erlang:phash2([node()]),
                                               erlang:monotonic_time(),
-                                              erlang:unique_integer()),
+                                              erlang:unique_integer()}),
                                   Elements = generate_unique(Card),
                                   Estimate = card(insert_many(Elements, new(P))),
                                   abs(Card - Estimate) / Card
@@ -330,7 +330,7 @@ perf_report() ->
 
     R = [begin
              io:format("."),
-             random:seed(1, 2, 3),
+             rand:seed(exs1024, {1, 2, 3}),
 
              M = trunc(math:pow(2, P)),
              InsertUs = Time(fun (Values, H) ->

--- a/test/hyper_test.erl
+++ b/test/hyper_test.erl
@@ -65,7 +65,7 @@ serialization_t() ->
 
 
 reduce_precision_t() ->
-    random:seed(1, 2, 3),
+    rand:seed(exs1024, {1, 2, 3}),
     Card = 1000,
     Values = generate_unique(Card),
     [begin
@@ -206,7 +206,7 @@ error_range_t() ->
           end,
     ExpectedError = 0.02,
     P = 14,
-    random:seed(1, 2, 3),
+    rand:seed(exs1024, {1, 2, 3}),
 
     [begin
          Estimate = trunc(hyper:card(Run(Card, P, Mod))),
@@ -215,7 +215,7 @@ error_range_t() ->
             Mod <- Mods].
 
 many_union_t() ->
-    random:seed(1, 2, 3),
+    rand:seed(exs1024, {1, 2, 3}),
     Card = 100,
     NumSets = 3,
 
@@ -256,7 +256,7 @@ many_union_t() ->
 
 
 union_t() ->
-    random:seed(1, 2, 3),
+    rand:seed(exs1024, {1, 2, 3}),
     Mod = hyper_binary_rle,
 
     LeftDistinct = sets:from_list(generate_unique(100)),
@@ -297,7 +297,7 @@ union_mixed_precision_t() ->
 
 
 small_big_union_t() ->
-    random:seed(1, 2, 3),
+    rand:seed(exs1024, {1, 2, 3}),
     SmallCard = 100,
     BigCard   = 15000, % switches to dense at 10922 items
 
@@ -318,7 +318,7 @@ small_big_union_t() ->
 
 
 intersect_card_t() ->
-    random:seed(1, 2, 3),
+    rand:seed(exs1024, {1, 2, 3}),
 
     LeftDistinct = sets:from_list(generate_unique(10000)),
 
@@ -386,9 +386,9 @@ gen_values() ->
     ?SIZED(Size, gen_values(Size)).
 
 gen_values(0) ->
-    [<<(random:uniform(100000000000000)):64/integer>>];
+    [<<(rand:uniform(100000000000000)):64/integer>>];
 gen_values(Size) ->
-    [<<(random:uniform(100000000000000)):64/integer>> | gen_values(Size-1)].
+    [<<(rand:uniform(100000000000000)):64/integer>> | gen_values(Size-1)].
 
 %%gen_values(0) ->
 %%    [non_empty(binary())];
@@ -519,7 +519,7 @@ random_bytes(N) ->
 
 random_bytes(Acc, 0) -> Acc;
 random_bytes(Acc, N) ->
-    Int = random:uniform(100000000000000),
+    Int = rand:uniform(100000000000000),
     random_bytes([<<Int:64/integer>> | Acc], N-1).
 
 


### PR DESCRIPTION
See also PRs #17 and #19.