### PR TITLE
Remove test failing in Erlang 20

### DIFF
--- a/test/hyper_test.erl
+++ b/test/hyper_test.erl
@@ -135,7 +135,6 @@ backend_t() ->
     ?assertEqual(Array, hyper:from_json(hyper:to_json(Array), hyper_array)),
     ?assertEqual(Bisect, hyper:from_json(hyper:to_json(Array), hyper_bisect)),
     ?assertEqual(Binary, hyper:from_json(hyper:to_json(Binary), hyper_binary)),
-    ?assertEqual(Carray, hyper:from_json(hyper:to_json(Carray), hyper_carray)),
 
 
     ?assertEqual(hyper:to_json(Gb), hyper:to_json(Array)),


### PR DESCRIPTION
Erlang 20+ no longer returns opaque enif_make_resource value. It has different reference id every time.

Basically this test no longer has any sense in a modern Erlang versions and very little we can do here. Let's just remove it.